### PR TITLE
fix: user/detail, rank 조회 시, User 내에 team 정보도 같이 조회되도록 relations 추가

### DIFF
--- a/apps/api/src/rank/rank.service.ts
+++ b/apps/api/src/rank/rank.service.ts
@@ -37,7 +37,9 @@ export class RankService {
       (a, b) => b[1] - a[1] // [userId, count] count를 기준으로 내림차순 정렬
     );
 
-    const userList = await this.dataSource.manager.find(User);
+    const userList = await this.dataSource.manager.find(User, {
+      relations: ["team"],
+    });
 
     const findUser = (userId: number) => {
       return userList.find((user) => user.id === userId);

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -22,6 +22,7 @@ export class UserService {
   async getUser({ userId }: { userId: number }): Promise<User> {
     const result = await this.dataSource.manager.findOne(User, {
       where: { id: userId },
+      relations: ["team"],
     });
 
     if (!result) {


### PR DESCRIPTION
- rank 에 team 이름이 안보이는 오류가 있어서, User 내 누락된 Team 정보도 같이 조회되도록 추가했습니다.
- 수정하면서 user/detail 에도 누락되어있어서 같이 추가했습니다.