### PR TITLE
fix: 좌석 3개 추가 (1, 7, 13) 에 따른 배치도 변경

### DIFF
--- a/apps/web/src/components/MobileReservation/index.styles.ts
+++ b/apps/web/src/components/MobileReservation/index.styles.ts
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
 const Container = styled.div`
   ${media.mobile`
    padding: 20px;
-  width: 500px;
+  width: 600px;
   border-radius: 12px;
   background-color: ${COLOR.white};
   `};

--- a/apps/web/src/components/Reservation/Desk/index.styles.ts
+++ b/apps/web/src/components/Reservation/Desk/index.styles.ts
@@ -7,7 +7,7 @@ const Container = styled.li<{ $isHovering?: boolean; isMine?: boolean }>`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 210px;
+  width: 175px;
   height: 120px;
   border-radius: 16px;
   color: ${COLOR.white};

--- a/apps/web/src/components/Reservation/index.tsx
+++ b/apps/web/src/components/Reservation/index.tsx
@@ -35,52 +35,13 @@ function Reservation({
 
   const fixedSeatList: Seat[] = [
     {
-      id: 8,
-      deskNo: 8,
+      id: 10,
+      deskNo: 10,
       reservations: [],
       fixedUser: {
-        id: 8,
+        id: 10,
         name: '김종하',
         team: teamDev,
-        email: '',
-        photo: '',
-        reservations: [],
-      },
-    },
-    {
-      id: 12,
-      deskNo: 12,
-      reservations: [],
-      fixedUser: {
-        id: 12,
-        name: '전상훈',
-        team: teamPo,
-        email: '',
-        photo: '',
-        reservations: [],
-      },
-    },
-    {
-      id: 13,
-      deskNo: 13,
-      reservations: [],
-      fixedUser: {
-        id: 13,
-        name: '박상유',
-        team: teamPo,
-        email: '',
-        photo: '',
-        reservations: [],
-      },
-    },
-    {
-      id: 14,
-      deskNo: 14,
-      reservations: [],
-      fixedUser: {
-        id: 14,
-        name: '기획 고정석',
-        team: teamPo,
         email: '',
         photo: '',
         reservations: [],
@@ -92,6 +53,45 @@ function Reservation({
       reservations: [],
       fixedUser: {
         id: 15,
+        name: '전상훈',
+        team: teamPo,
+        email: '',
+        photo: '',
+        reservations: [],
+      },
+    },
+    {
+      id: 16,
+      deskNo: 16,
+      reservations: [],
+      fixedUser: {
+        id: 16,
+        name: '박상유',
+        team: teamPo,
+        email: '',
+        photo: '',
+        reservations: [],
+      },
+    },
+    {
+      id: 17,
+      deskNo: 17,
+      reservations: [],
+      fixedUser: {
+        id: 17,
+        name: '이승한',
+        team: teamPo,
+        email: '',
+        photo: '',
+        reservations: [],
+      },
+    },
+    {
+      id: 18,
+      deskNo: 18,
+      reservations: [],
+      fixedUser: {
+        id: 18,
         name: '성인식',
         team: teamPo,
         email: '',
@@ -171,20 +171,20 @@ function Reservation({
 
       <Styled.SeatContainer>
         <Styled.SeatList>
-          {[...Array(5)]
-            .map((_, i) => i + 1) // 1 ~ 5 까지의 좌석
+          {[...Array(6)]
+            .map((_, i) => i + 1) // 1 ~ 6 까지의 좌석
             .map((deskNo, i) => renderDesk(deskNo, i))}
         </Styled.SeatList>
 
         <Styled.SeatList>
-          {[...Array(5)]
-            .map((_, i) => i + 6) // 6 ~ 10 까지의 좌석
+          {[...Array(6)]
+            .map((_, i) => i + 7) // 6 ~ 12 까지의 좌석
             .map((deskNo, i) => renderDesk(deskNo, i))}
         </Styled.SeatList>
 
         <Styled.SeatList>
-          {[...Array(5)]
-            .map((_, i) => i + 11) // 11 ~ 15 까지의 좌석
+          {[...Array(6)]
+            .map((_, i) => i + 13) // 13 ~ 18 까지의 좌석
             .map((deskNo, i) => renderDesk(deskNo, i))}
         </Styled.SeatList>
       </Styled.SeatContainer>

--- a/apps/web/src/constants/fixedSeatList.ts
+++ b/apps/web/src/constants/fixedSeatList.ts
@@ -14,39 +14,13 @@ const teamPo: Team = {
 
 const fixedSeatList: Seat[] = [
   {
-    id: 8,
-    deskNo: 8,
+    id: 10,
+    deskNo: 10,
     reservations: [],
     fixedUser: {
-      id: 8,
+      id: 10,
       name: '김종하',
       team: teamDev,
-      email: '',
-      photo: '',
-      reservations: [],
-    },
-  },
-  {
-    id: 13,
-    deskNo: 13,
-    reservations: [],
-    fixedUser: {
-      id: 13,
-      name: '박상유',
-      team: teamPo,
-      email: '',
-      photo: '',
-      reservations: [],
-    },
-  },
-  {
-    id: 14,
-    deskNo: 14,
-    reservations: [],
-    fixedUser: {
-      id: 14,
-      name: '기획 고정석',
-      team: teamPo,
       email: '',
       photo: '',
       reservations: [],
@@ -58,6 +32,45 @@ const fixedSeatList: Seat[] = [
     reservations: [],
     fixedUser: {
       id: 15,
+      name: '전상훈',
+      team: teamPo,
+      email: '',
+      photo: '',
+      reservations: [],
+    },
+  },
+  {
+    id: 16,
+    deskNo: 16,
+    reservations: [],
+    fixedUser: {
+      id: 16,
+      name: '박상유',
+      team: teamPo,
+      email: '',
+      photo: '',
+      reservations: [],
+    },
+  },
+  {
+    id: 17,
+    deskNo: 17,
+    reservations: [],
+    fixedUser: {
+      id: 17,
+      name: '이승한',
+      team: teamPo,
+      email: '',
+      photo: '',
+      reservations: [],
+    },
+  },
+  {
+    id: 18,
+    deskNo: 18,
+    reservations: [],
+    fixedUser: {
+      id: 18,
       name: '성인식',
       team: teamPo,
       email: '',


### PR DESCRIPTION
회의실 방향으로 좌석이 3개 추가되었습니다 (바뀐 좌석번호 기준 1번, 7번, 13번)

데스크탑
<img width="1316" alt="Screenshot 2024-10-30 at 7 45 16 PM" src="https://github.com/user-attachments/assets/aaa49096-a8ef-4c7c-821c-6c3478a8aede">


모바일
<img width="399" alt="Screenshot 2024-10-30 at 7 45 43 PM" src="https://github.com/user-attachments/assets/6cfb6314-fd0f-4bba-be93-9c32bdcfb8da">
<img width="392" alt="Screenshot 2024-10-30 at 7 45 48 PM" src="https://github.com/user-attachments/assets/2c05a252-342d-4ece-9620-6e021323a158">

함께 되어야할 작업
- seat 테이블에 좌석 추가
- 기존 reservation 데이터를 바뀐 seatId에 맞게 마이그레이션
[seat 마이그레이션]
1 -> 2
2 -> 3
3 -> 4
4 -> 5
5 -> 6
6 -> 8
7 -> 9
9 -> 11
10 -> 12
12 -> 14
